### PR TITLE
Add support for LiteX boards which run their main program from flash.

### DIFF
--- a/ports/fupy/Makefile
+++ b/ports/fupy/Makefile
@@ -70,27 +70,34 @@ SRC_C = \
 
 # FIXME: Should use crt0 from newlib? However it seems to cause memory access
 # at 0x0
+
 ifeq ($(COPY_TO_MAIN_RAM), 1)
-SRC_S = crt0-$(CPU).S
+CRT0_S ?= $(LIBBASE_DIRECTORY)/crt0-$(CPU).S
+CRT0_O = $(BUILD)/crt0-$(CPU)-ctr.o
+CRT0FLAGS = ""
+else ifeq ($(EXECUTE_IN_PLACE), 1)
+CRT0_S ?= $(LIBBASE_DIRECTORY)/crt0-$(CPU).S
+CRT0_O = $(BUILD)/crt0-$(CPU)-xip.o
+CRT0FLAGS = -DEXECUTE_IN_PLACE
 else
-SRC_S = crt0-$(CPU)-flash.S
+$(error You need to define one of COPY_TO_MAIN_RAM or EXECUTE_IN_PLACE to 1)
 endif
 
-OBJ = $(addprefix $(BUILD)/, $(SRC_S:.S=.o)) $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+# No extra assembly files for now.
+SRC_S = ""
+
+OBJ = $(addprefix $(BUILD)/, $(SRC_S:.S=.o)) $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o)) $(CRT0_O)
 
 all: $(BUILD)/firmware.bin
 
 # List of sources for qstr extraction
 SRC_QSTR += $(SRC_C) $(SRC_LIB)
 
-$(BUILD)/crt0-$(CPU).S: $(LIBBASE_DIRECTORY)/crt0-$(CPU).S
-	cp $< $@
-
-# Flash crt0 override for normal assembler rule- needed to distinguish
+# crt0 override for normal assembler rule- needed to distinguish
 # whether we need to assemble a crt0 that copies a data section to RAM from
 # flash, or a crt0 that assumes a bootloader does it ahead of time.
-$(BUILD)/crt0-$(CPU)-flash.o: $(BUILD)/crt0-$(CPU).S
-	$(CC) -c -DFLASH_DATA_SECTION $(CFLAGS) -o $@ $<
+$(CRT0_O): $(CRT0_S)
+	$(CC) -c $(CFLAGS) $(CRT0FLAGS) -o $@ $<
 
 $(BUILD)/_frozen_mpy.c: frozentest.mpy $(BUILD)/genhdr/qstrdefs.generated.h
 	$(ECHO) "MISC freezing bytecode"

--- a/ports/fupy/Makefile
+++ b/ports/fupy/Makefile
@@ -46,7 +46,12 @@ ifneq ($(DEBUG), 1)
 CFLAGS += -DNDEBUG
 endif
 
-LDFLAGS += -T litex.ld -Wl,-Map=$@.map -Wl,--cref 
+ifeq ($(COPY_TO_MAIN_RAM), 1)
+LDFLAGS += -T litex.ld -Wl,-Map=$@.map -Wl,--cref
+else
+LDFLAGS += -T litex-flash.ld -Wl,-Map=$@.map -Wl,--cref
+endif
+
 LDFLAGS += -L$(BUILDINC_DIRECTORY)
 LIBS = -Wl,-lc -Wl,-lm
 
@@ -65,7 +70,11 @@ SRC_C = \
 
 # FIXME: Should use crt0 from newlib? However it seems to cause memory access
 # at 0x0
+ifeq ($(COPY_TO_MAIN_RAM), 1)
 SRC_S = crt0-$(CPU).S
+else
+SRC_S = crt0-$(CPU)-flash.S
+endif
 
 OBJ = $(addprefix $(BUILD)/, $(SRC_S:.S=.o)) $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
@@ -76,6 +85,12 @@ SRC_QSTR += $(SRC_C) $(SRC_LIB)
 
 $(BUILD)/crt0-$(CPU).S: $(LIBBASE_DIRECTORY)/crt0-$(CPU).S
 	cp $< $@
+
+# Flash crt0 override for normal assembler rule- needed to distinguish
+# whether we need to assemble a crt0 that copies a data section to RAM from
+# flash, or a crt0 that assumes a bootloader does it ahead of time.
+$(BUILD)/crt0-$(CPU)-flash.o: $(BUILD)/crt0-$(CPU).S
+	$(CC) -c -DFLASH_DATA_SECTION $(CFLAGS) -o $@ $<
 
 $(BUILD)/_frozen_mpy.c: frozentest.mpy $(BUILD)/genhdr/qstrdefs.generated.h
 	$(ECHO) "MISC freezing bytecode"

--- a/ports/fupy/Makefile
+++ b/ports/fupy/Makefile
@@ -84,9 +84,9 @@ $(error You need to define one of COPY_TO_MAIN_RAM or EXECUTE_IN_PLACE to 1)
 endif
 
 # No extra assembly files for now.
-SRC_S = 
+SRC_S =
 
-OBJ = $(addprefix $(BUILD)/, $(SRC_S:.S=.o)) $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o)) $(CRT0_O)
+OBJ =  $(CRT0_O) $(addprefix $(BUILD)/, $(SRC_S:.S=.o)) $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
 all: $(BUILD)/firmware.bin
 

--- a/ports/fupy/Makefile
+++ b/ports/fupy/Makefile
@@ -84,7 +84,7 @@ $(error You need to define one of COPY_TO_MAIN_RAM or EXECUTE_IN_PLACE to 1)
 endif
 
 # No extra assembly files for now.
-SRC_S = ""
+SRC_S = 
 
 OBJ = $(addprefix $(BUILD)/, $(SRC_S:.S=.o)) $(PY_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o)) $(CRT0_O)
 

--- a/ports/fupy/hw/common.h
+++ b/ports/fupy/hw/common.h
@@ -1,10 +1,52 @@
 #ifndef __HW_COMMON_H
 #define __HW_COMMON_H
 
+#include <stdint.h>
+
+/* To overwrite CSR accessors, define extern, non-inlined versions
+ * of csr_read[bwl]() and csr_write[bwl](), and define
+ * CSR_ACCESSORS_DEFINED.
+ */
+
+#ifndef CSR_ACCESSORS_DEFINED
+#define CSR_ACCESSORS_DEFINED
+
 #ifdef __ASSEMBLER__
 #define MMPTR(x) x
-#else
+#else /* ! __ASSEMBLER__ */
 #define MMPTR(x) (*((volatile unsigned int *)(x)))
-#endif
 
-#endif
+static inline void csr_writeb(uint8_t value, uint32_t addr)
+{
+	*((volatile uint8_t *)addr) = value;
+}
+
+static inline uint8_t csr_readb(uint32_t addr)
+{
+	return *(volatile uint8_t *)addr;
+}
+
+static inline void csr_writew(uint16_t value, uint32_t addr)
+{
+	*((volatile uint16_t *)addr) = value;
+}
+
+static inline uint16_t csr_readw(uint32_t addr)
+{
+	return *(volatile uint16_t *)addr;
+}
+
+static inline void csr_writel(uint32_t value, uint32_t addr)
+{
+	*((volatile uint32_t *)addr) = value;
+}
+
+static inline uint32_t csr_readl(uint32_t addr)
+{
+	return *(volatile uint32_t *)addr;
+}
+#endif /* ! __ASSEMBLER__ */
+
+#endif /* ! CSR_ACCESSORS_DEFINED */
+
+#endif /* __HW_COMMON_H */

--- a/ports/fupy/litex-flash.ld
+++ b/ports/fupy/litex-flash.ld
@@ -1,0 +1,62 @@
+INCLUDE generated/output_format.ld
+INCLUDE generated/regions.ld
+ENTRY(_start)
+/*
+INPUT(crti.o crtbegin.o crt0.o crtend.o crtn.o)
+GROUP(-lgloss -lnosys -lc -lgcc)
+*/
+__DYNAMIC = 0;
+
+SECTIONS
+{
+	.fbi :
+	{
+		. = . + 8; /* Firmware Base Image format (len/crc) data comes first. */
+	} > user_flash
+
+	.text :
+	{
+		_ftext = .;
+		*(.text .stub .text.* .gnu.linkonce.t.*)
+		_etext = .;
+	} > user_flash
+
+	.rodata :
+	{
+		. = ALIGN(4);
+		_frodata = .;
+		*(.rodata .rodata.* .gnu.linkonce.r.*)
+		*(.rodata1)
+		_erodata = .;
+	} > user_flash
+
+	.data : AT (ADDR(.rodata) + SIZEOF (.rodata))
+	{
+		. = ALIGN(4);
+		_fdata = .;
+		*(.data .data.* .gnu.linkonce.d.*)
+		*(.data1)
+		_gp = ALIGN(16);
+		*(.sdata .sdata.* .gnu.linkonce.s.*)
+		_edata = ALIGN(16); /* Make sure _edata is >= _gp. */
+	} > sram
+
+	.bss :
+	{
+		. = ALIGN(4);
+		_fbss = .;
+		__bss_start = .;
+		*(.dynsbss)
+		*(.sbss .sbss.* .gnu.linkonce.sb.*)
+		*(.scommon)
+		*(.dynbss)
+		*(.bss .bss.* .gnu.linkonce.b.*)
+		*(COMMON)
+		. = ALIGN(4);
+		_ebss = .;
+		_end = .;
+		end = .;
+	} > sram
+}
+
+PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);


### PR DESCRIPTION
Self explanatory, this PR adds logic to distinguish LiteX-supported boards which run their main program from flash from those who load their program into DRAM. The Makefile queries the [recently-added](https://github.com/enjoy-digital/litex/pull/99) `COPY_TO_MAIN_RAM` Makefile variable to determine which linker script to use.

The new behavior shouldn't affect any previously-supported boards.