### PR TITLE
Include Guard Improvement

### DIFF
--- a/ports/fupy/litex_leds.c
+++ b/ports/fupy/litex_leds.c
@@ -6,7 +6,7 @@
 
 #include "generated/csr.h"
 
-#ifndef CSR_CAS_BASE
+#if !defined(CSR_CAS_BASE) || !defined(CSR_CAS_LEDS_OUT_ADDR)
 static inline unsigned char cas_leds_out_read(void) {
 	return 0;
 }

--- a/ports/fupy/litex_switches.c
+++ b/ports/fupy/litex_switches.c
@@ -6,7 +6,7 @@
 
 #include "generated/csr.h"
 
-#ifndef CSR_CAS_BASE
+#if !defined(CSR_CAS_BASE) || !defined(CSR_CAS_SWITCHES_IN_ADDR)
 static inline unsigned char cas_switches_in_read(void) {
     return 0;
 }


### PR DESCRIPTION
While fupy has an include guard testing for the existence of `ControlAndStatus`, some boards may not include all of the components of the `ControlAndStatus` module. This PR improves the include guard to enable the stub read and write functions for boards lacking one or more components of `ControlAndStatus`. Prior to this commit, the fupy build would error out with an unresolved symbol for csr read/write functions during linking.