### PR TITLE
RISCV32 support

### DIFF
--- a/ports/fupy/Makefile
+++ b/ports/fupy/Makefile
@@ -50,9 +50,9 @@ CFLAGS += -DNDEBUG
 endif
 
 ifeq ($(COPY_TO_MAIN_RAM), 1)
-LDFLAGS += -T litex.ld -Wl,-Map=$@.map -Wl,--cref
+LDFLAGS += -nostartfiles -T litex.ld -Wl,-Map=$@.map -Wl,--cref
 else
-LDFLAGS += -T litex-flash.ld -Wl,-Map=$@.map -Wl,--cref
+LDFLAGS += -nostartfiles -T litex-flash.ld -Wl,-Map=$@.map -Wl,--cref
 endif
 
 LDFLAGS += -L$(BUILDINC_DIRECTORY)
@@ -87,6 +87,16 @@ else
 $(error You need to define one of COPY_TO_MAIN_RAM or EXECUTE_IN_PLACE to 1)
 endif
 
+# CPU-specific overrides.
+ifeq ($(CPU), picorv32)
+# Extract the arch-specific flags, otherwise firmware won't link.
+LDFLAGS += $(filter -march=% -mabi=%, $(CPUFLAGS))
+# picorv32 needs a special assembly include to compile crt0.
+ASFLAGS += -I$(SOC_DIRECTORY)/software/include/base
+else ifeq ($(CPU), vexriscv)
+LDFLAGS += $(filter -march=% -mabi=%, $(CPUFLAGS))
+endif
+
 # No extra assembly files for now.
 SRC_S =
 
@@ -101,7 +111,7 @@ SRC_QSTR += $(SRC_C) $(SRC_LIB)
 # whether we need to assemble a crt0 that copies a data section to RAM from
 # flash, or a crt0 that assumes a bootloader does it ahead of time.
 $(CRT0_O): $(CRT0_S)
-	$(CC) -c $(CFLAGS) $(CRT0FLAGS) -o $@ $<
+	$(CC) -c $(ASFLAGS) $(CFLAGS) $(CRT0FLAGS) -o $@ $<
 
 $(BUILD)/_frozen_mpy.c: frozentest.mpy $(BUILD)/genhdr/qstrdefs.generated.h
 	$(ECHO) "MISC freezing bytecode"

--- a/ports/fupy/Makefile
+++ b/ports/fupy/Makefile
@@ -78,7 +78,7 @@ SRC_C = \
 ifeq ($(COPY_TO_MAIN_RAM), 1)
 CRT0_S ?= $(LIBBASE_DIRECTORY)/crt0-$(CPU).S
 CRT0_O = $(BUILD)/crt0-$(CPU)-ctr.o
-CRT0FLAGS = ""
+CRT0FLAGS =
 else ifeq ($(EXECUTE_IN_PLACE), 1)
 CRT0_S ?= $(LIBBASE_DIRECTORY)/crt0-$(CPU).S
 CRT0_O = $(BUILD)/crt0-$(CPU)-xip.o

--- a/ports/fupy/litex-flash.ld
+++ b/ports/fupy/litex-flash.ld
@@ -27,6 +27,9 @@ SECTIONS
 		_frodata = .;
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
 		*(.rodata1)
+		/* On RISCV, normally placed near _gp. Keeping RAM footprint low
+		is higher priority than speed here. */
+		*(.srodata .srodata.*)
 		_erodata = .;
 	} > user_flash
 

--- a/ports/fupy/litex.ld
+++ b/ports/fupy/litex.ld
@@ -33,6 +33,7 @@ SECTIONS
 		*(.data1)
 		_gp = ALIGN(16);
 		*(.sdata .sdata.* .gnu.linkonce.s.*)
+		*(.srodata .srodata.*)
 		_edata = .;
 	} > main_ram
 


### PR DESCRIPTION
This PR includes all the changes I needed to make to get a working RISCV compile. Specifically, we need to extract the correct arch and ABI, and add a few extra flags to the linker command line.

These changes do not affect lm32 compilation.